### PR TITLE
Fetch all documents including those in folders

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -185,7 +185,7 @@ function createServer(config: CliConfig): McpServer {
         "",
         "## Workflow: Reading Documents",
         "1. Use itglue_list_organizations to find the organization ID.",
-        "2. Use itglue_list_documents with the org ID to find documents.",
+        "2. Use itglue_list_documents with the org ID to find documents (includes documents in folders).",
         "3. Use itglue_get_document to retrieve full content (may be truncated at 25k chars).",
         "4. If content is truncated, use itglue_list_document_sections then itglue_get_document_section for individual sections.",
         "",


### PR DESCRIPTION
## Summary
- The IT Glue API only returns root-level documents by default, making folder-nested documents invisible to the MCP server
- `itglue_list_documents` now makes two API calls — one for root documents and one with `filter[document-folder-id][ne]=null` for folder documents — then merges and deduplicates the results
- Updated server instructions to note that folder documents are included

Closes #3

## Test plan
- [x] All 181 existing + new tests pass (`npm test`)
- [x] TypeScript build succeeds (`npm run build`)
- [ ] Manual test: call `itglue_list_documents` for an org with folder-nested documents and confirm they appear in results

🤖 Generated with [Claude Code](https://claude.com/claude-code)